### PR TITLE
FIX: use conda shell hooks to avoid `conda activate` failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace

--- a/README.rst
+++ b/README.rst
@@ -95,8 +95,8 @@ Installing Development Requirements
 
   $ pip install -Ur requirements.txt
   $ pip install -Ur dev-requirements.txt
-  
-  
+
+
 Cookiecutter?
 -------------
 

--- a/{{cookiecutter.ioc_name}}/initialize.sh
+++ b/{{cookiecutter.ioc_name}}/initialize.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Usage: bash initialize.sh
+#   This script will use the configuration settings in ``config.sh`` to
+#   create a conda environment in this directory named "conda_env".
+#   This should be run *after* config.sh has been customized.
 
 . config.sh
 
@@ -6,7 +10,13 @@ git submodule update --init --recursive
 
 set -e
 
+# Run conda bash hooks to ensure that conda activate will work:
+eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+
+# Create the new environment with the configured Python version
 conda create --yes --prefix "$PWD/conda_env" python=${PYTHON_VERSION}
+
+# Activate the IOC environment
 . "${TOP}/activate_env.sh"
 
 for pkg in ${PACKAGES}; do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Avoids the issue described in #2 
* Updated pre-commit settings
* Ran pre-commit to fix style

## Motivation and Context
Closes #2 

## How Has This Been Tested?
Tested with`/reg/g/pcds/epics-dev/wwright8/ioc/rix/ioc-rix-at1k2-calc`

## Where Has This Been Documented?
Issue and PR text